### PR TITLE
Add autocompletion to help subcommand

### DIFF
--- a/libexec/sub-help
+++ b/libexec/sub-help
@@ -27,6 +27,12 @@ print_help() {
   fi
 }
 
+# Provide sub completions
+if [ "$1" = "--complete" ]; then
+  exec "sub-commands"
+  exit
+fi
+
 case "$1" in
 "") echo "Usage: sub <command> [<args>]
 


### PR DESCRIPTION
I found this useful for myself since I kept trying to type `sub help com[TAB]` but was not autocompleting.

`sub` is really nice. I was actually using `thor` for a collection of tasks, but `sub` is much simpler for what I need.
