### PR TITLE
Allow colors in summary view

### DIFF
--- a/libexec/sub-help
+++ b/libexec/sub-help
@@ -8,7 +8,7 @@ print_summaries() {
       if [ -n "$summary" ]; then
         local name=$(basename $file | sed 's/sub-//')
         echo "$name" | awk '{ printf "   %-20s   ", $1}'
-        echo -n $summary
+        echo -en $summary
         echo
       fi
     fi


### PR DESCRIPTION
If some commands are protected for a certain group, but you still want to regroup them under one single sub.

Allow colors in summary view (using ANSI Escape Sequences). 
Example here: http://d.pr/i/3yyn

Example usage: 
# Summary: \033[1;31;40mManipulate farms (enable/disable, weight...) [sysadmin only]\033[0m
