### PR TITLE
Fixed ENVNAME so that sub supports commands with dashes in the name

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -8,7 +8,7 @@ if [ -z "$NAME" ]; then
 fi
 
 SUBNAME=$(echo $NAME | tr '[A-Z]' '[a-z]')
-ENVNAME="$(echo $NAME | tr '[a-z]' '[A-Z]')_ROOT"
+ENVNAME="$(echo $NAME | tr '[a-z]' '[A-Z]' | tr '-' '_')_ROOT"
 
 echo "Preparing your '$SUBNAME' sub!"
 


### PR DESCRIPTION
I wanted to use a sub called "something-admin" but when bin/something-admin tries to run:

export _SOMETHING-ADMIN_ROOT="$(abs_dirname "$libexec_path")"

It fails as it contains a dash, so these should be converted to underscores.

Cheers z0mbix
