### PR TITLE
Allow sub names containing dashes

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -8,7 +8,7 @@ if [ -z "$NAME" ]; then
 fi
 
 SUBNAME=$(echo $NAME | tr '[A-Z]' '[a-z]')
-ENVNAME="$(echo $NAME | tr '[a-z]' '[A-Z]')_ROOT"
+ENVNAME="$(echo $NAME | tr '[a-z-]' '[A-Z_]')_ROOT"
 
 echo "Preparing your '$SUBNAME' sub!"
 


### PR DESCRIPTION
Replace dash with underscore to allow sub names that include a dash
e.g. "sub-admin".
