### PR TITLE
fall through to default bash completion

### DIFF
--- a/completions/sub.bash
+++ b/completions/sub.bash
@@ -6,9 +6,13 @@ _sub() {
     COMPREPLY=( $(compgen -W "$(sub commands)" -- "$word") )
   else
     local command="${COMP_WORDS[1]}"
-    local completions="$(sub completions "$command")"
-    COMPREPLY=( $(compgen -W "$completions" -- "$word") )
+    local completions="$(sub completions "$command" ${COMP_WORDS[@]:2})"
+    if [ "$completions" ]; then
+      COMPREPLY=( $(compgen -W "$completions" -- "$word") )
+    else
+      return 1
+    fi
   fi
 }
 
-complete -F _sub sub
+complete -o default -F _sub sub


### PR DESCRIPTION
When there are no completions for a command, fall through to default bash completion. Fixes #16.

It's still necessary to add this in your command if it produces output:

``` bash
# Provide sub completions
if [ "$1" = "--complete" ]; then
  exit 0
fi
```

I also added the patch from #12.
