### PR TITLE
Added autoconf tooling 

### DIFF
--- a/bin/sub
+++ b/bin/sub
@@ -1,1 +1,0 @@
-../libexec/sub

--- a/debian/control
+++ b/debian/control
@@ -1,0 +1,10 @@
+Package: helloworld
+Version: 1.0-1
+Section: base
+Priority: optional
+Architecture: i386
+Depends: libsomethingorrather (>= 1.2.13), anotherDependency (>= 1.2.6)
+Maintainer: Your Name <you@email.com>
+Description: Hello World
+ When you need some sunshine, just run this
+ small program!

--- a/libexec/main
+++ b/libexec/main
@@ -19,8 +19,14 @@ abs_dirname() {
   cd "$cwd"
 }
 
-libexec_path=@prefix@/libexec
 #libexec_path="$(abs_dirname "$0")"
+sjalv=$(basename $0)
+libexec_path=@prefix@/libexec/$sjalv
+
+if [[ "${libexec_path}" = *"@"* ]]; then
+        libexec_path="$(abs_dirname "$0")" #Substitution has not happened -> dev version
+fi
+
 export _SUB_ROOT="$(abs_dirname "$libexec_path")"
 export PATH="${libexec_path}:$PATH"
 

--- a/libexec/sub
+++ b/libexec/sub
@@ -19,7 +19,8 @@ abs_dirname() {
   cd "$cwd"
 }
 
-libexec_path="$(abs_dirname "$0")"
+libexec_path=@prefix@/libexec
+#libexec_path="$(abs_dirname "$0")"
 export _SUB_ROOT="$(abs_dirname "$libexec_path")"
 export PATH="${libexec_path}:$PATH"
 

--- a/prepare.sh
+++ b/prepare.sh
@@ -13,6 +13,7 @@ ENVNAME="$(echo $NAME | tr '[a-z-]' '[A-Z_]')_ROOT"
 echo "Preparing your '$SUBNAME' sub!"
 
 if [ "$NAME" != "sub" ]; then
+  test -d bin && mkdir bin
   test -d share/sub && mv share/sub share/$SUBNAME
 
   for file in libexec/sub*; do

--- a/prepare.sh
+++ b/prepare.sh
@@ -42,7 +42,8 @@ SUBDIRS = bin libexec etc
 __EOF__
 
 cat << __EOF__ > libexec/Makefile.am
-dist_libexec_SCRIPTS = $SUBNAME\\
+#dist_libexec_SCRIPTS =  # to omit subdir
+nobase_dist_libexec_SCRIPTS = $SUBNAME\\
 	$SUBNAME-commands\\
 	$SUBNAME-completions\\
 	$SUBNAME-help\\
@@ -55,12 +56,14 @@ dist_bin_SCRIPTS = $SUBNAME
 __EOF__
 
 test -d ./etc || mkdir ./etc
+test -d ./etc/$SUBNAME || mkdir ./etc/$SUBNAME
 
 cat << __EOF__ > etc/Makefile.am
-dist_sysconf_DATA = $SUBNAME.conf
+#dist_sysconf_DATA = $SUBNAME.conf # to omit subdir
+nobase_dist_sysconf_DATA = $SUBNAME.conf
 __EOF__
 
-test -f  etc/$SUBNAME.conf || cat << __EOF__ > etc/$SUBNAME.conf
+test -f  etc/$SUBNAME/$SUBNAME.conf || cat << __EOF__ > etc/$SUBNAME/$SUBNAME.conf
 #Here your configuration
 __EOF__
 

--- a/prepare.sh
+++ b/prepare.sh
@@ -66,6 +66,7 @@ cat << EOF > makedeb.sh
 #!/usr/bin/env bash
 
 VERS=1.0.0
+TARGET_DIR=../target
 cd \$(dirname \$0);
 CURRDIR=\$(pwd)
 
@@ -74,7 +75,7 @@ mkdir -p \${workdir}/DEBIAN
 cp -r ./debian/* \${workdir}/DEBIAN
 ./configure "\$@"
 make install DESTDIR=\${workdir}
-dpkg-deb --build \${workdir} ../$SUBNAME-\$VERS.deb
+dpkg-deb --build \${workdir} \$TARGET_DIR/$SUBNAME-\$VERS.deb
 
 EOF
 chmod 755 makedeb.sh

--- a/prepare.sh
+++ b/prepare.sh
@@ -13,7 +13,7 @@ ENVNAME="$(echo $NAME | tr '[a-z-]' '[A-Z_]')_ROOT"
 echo "Preparing your '$SUBNAME' sub!"
 
 if [ "$NAME" != "sub" ]; then
-  test -d bin && mkdir bin
+  test -d bin || mkdir bin
   test -d share/sub && mv share/sub share/$SUBNAME
 
   for file in libexec/sub*; do

--- a/prepare.sh
+++ b/prepare.sh
@@ -25,11 +25,42 @@ if [ "$NAME" != "sub" ]; then
     chmod a+x $file
   done
 
-  ln -s ../libexec/$SUBNAME bin/$SUBNAME
+  ln -s ../libexec/$SUBNAME bin/$SUBNAME".in"
 fi
+
+cat << __EOF__ > configure.ac
+AC_INIT([$SUBNAME], [0.1], [paolo@lulli.net], [$SUBNAME])
+AC_CONFIG_FILES([Makefile bin/Makefile libexec/Makefile bin/$SUBNAME])
+AM_INIT_AUTOMAKE(foreign)
+#AC_PROG_CC
+AC_PROG_INSTALL
+AC_OUTPUT
+__EOF__
+
+cat << __EOF__ > Makefile.am
+SUBDIRS = bin libexec
+__EOF__
+
+cat << __EOF__ > libexec/Makefile.am
+dist_libexec_SCRIPTS = $SUBNAME\
+	$SUBNAME-commands\
+	$SUBNAME-completions\
+	$SUBNAME-help\
+	$SUBNAME-init\
+	$SUBNAME-sh-shell
+__EOF__
+
+cat << __EOF__ > bin/Makefile.am
+dist_bin_SCRIPTS = $SUBNAME
+__EOF__
 
 rm README.md
 rm prepare.sh
+
+echo "#! /bin/sh" > automake.sh 
+echo "aclocal && automake -a -c && autoconf" >> automake.sh 
+chmod 755 automake.sh
+./automake.sh
 
 echo "Done! Enjoy your new sub! If you're happy with your sub, run:"
 echo

--- a/prepare.sh
+++ b/prepare.sh
@@ -74,7 +74,7 @@ mkdir -p \${workdir}/DEBIAN
 cp -r ./debian/* \${workdir}/DEBIAN
 ./configure "\$@"
 make install DESTDIR=\${workdir}
-dpkg-deb --build \${workdir} ../$SUBNAME-$VERS.deb
+dpkg-deb --build \${workdir} ../$SUBNAME-\$VERS.deb
 
 EOF
 chmod 755 makedeb.sh

--- a/prepare.sh
+++ b/prepare.sh
@@ -74,7 +74,7 @@ mkdir -p \${workdir}/DEBIAN
 cp -r ./debian/* \${workdir}/DEBIAN
 ./configure "\$@"
 make install DESTDIR=\${workdir}
-dpkg-deb --build \${workdir} ../\$SUBNAME-\$VERS.deb
+dpkg-deb --build \${workdir} ../$SUBNAME-$VERS.deb
 
 EOF
 chmod 755 makedeb.sh

--- a/prepare.sh
+++ b/prepare.sh
@@ -13,10 +13,9 @@ ENVNAME="$(echo $NAME | tr '[a-z-]' '[A-Z_]')_ROOT"
 echo "Preparing your '$SUBNAME' sub!"
 
 if [ "$NAME" != "sub" ]; then
-  rm bin/sub
-  mv share/sub share/$SUBNAME
+  test -d share/sub && mv share/sub share/$SUBNAME
 
-  for file in **/sub*; do
+  for file in libexec/sub*; do
     sed "s/sub/$SUBNAME/g;s/SUB_ROOT/$ENVNAME/g" "$file" > $(echo $file | sed "s/sub/$SUBNAME/")
     rm $file
   done
@@ -25,7 +24,19 @@ if [ "$NAME" != "sub" ]; then
     chmod a+x $file
   done
 
-  ln -s ../libexec/$SUBNAME bin/$SUBNAME".in"
+  mkdir libexec/tmp
+  mv libexec/$SUBNAME*  libexec/tmp && mv libexec/tmp libexec/$SUBNAME
+  #ln -s $(pwd)/libexec/$SUBNAME/main bin/$SUBNAME".in"
+  
+#  sed "s/sub/$SUBNAME/g;s/SUB_ROOT/$ENVNAME/g" "libexec/main" > /tmp/libexecmain \
+#	&& cp /tmp/libexecmain libexec/$SUBNAME/main \
+#	&&  chmod a+x libexec/$SUBNAME/main\
+#	&& rm libexec/main
+  sed "s/sub/$SUBNAME/g;s/SUB_ROOT/$ENVNAME/g" "libexec/main" > /tmp/libexecmain \
+	&& cp /tmp/libexecmain bin/$SUBNAME".in" \
+	&& cp /tmp/libexecmain libexec/$SUBNAME/main 
+#	&& rm libexec/main
+  #ln -s bin/$SUBNAME".in" $(pwd)/libexec/$SUBNAME/main 
 fi
 
 cat << __EOF__ > configure.ac
@@ -43,7 +54,8 @@ __EOF__
 
 cat << __EOF__ > libexec/Makefile.am
 #dist_libexec_SCRIPTS =  # to omit subdir
-nobase_dist_libexec_SCRIPTS = $SUBNAME/$SUBNAME\\
+nobase_dist_libexec_SCRIPTS = $SUBNAME\\
+	$SUBNAME/main\\
 	$SUBNAME/$SUBNAME-commands\\
 	$SUBNAME/$SUBNAME-completions\\
 	$SUBNAME/$SUBNAME-help\\

--- a/prepare.sh
+++ b/prepare.sh
@@ -62,6 +62,23 @@ echo "aclocal && automake -a -c && autoconf" >> automake.sh
 chmod 755 automake.sh
 ./automake.sh
 
+cat << EOF > makedeb.sh
+#!/usr/bin/env bash
+
+VERS=1.0.0
+cd \$(dirname \$0);
+CURRDIR=\$(pwd)
+
+workdir=\$(mktemp -d /tmp/mkdebian_XXXXXXXX)
+mkdir -p \${workdir}/DEBIAN
+cp -r ./debian/* \${workdir}/DEBIAN
+./configure "\$@"
+make install DESTDIR=\${workdir}
+dpkg-deb --build \${workdir} ../\$SUBNAME-\$VERS.deb
+
+EOF
+chmod 755 makedeb.sh
+
 echo "Done! Enjoy your new sub! If you're happy with your sub, run:"
 echo
 echo "    rm -rf .git"

--- a/prepare.sh
+++ b/prepare.sh
@@ -43,12 +43,12 @@ __EOF__
 
 cat << __EOF__ > libexec/Makefile.am
 #dist_libexec_SCRIPTS =  # to omit subdir
-nobase_dist_libexec_SCRIPTS = $SUBNAME\\
-	$SUBNAME-commands\\
-	$SUBNAME-completions\\
-	$SUBNAME-help\\
-	$SUBNAME-init\\
-	$SUBNAME-sh-shell
+nobase_dist_libexec_SCRIPTS = $SUBNAME/$SUBNAME\\
+	$SUBNAME/$SUBNAME-commands\\
+	$SUBNAME/$SUBNAME-completions\\
+	$SUBNAME/$SUBNAME-help\\
+	$SUBNAME/$SUBNAME-init\\
+	$SUBNAME/$SUBNAME-sh-shell
 __EOF__
 
 cat << __EOF__ > bin/Makefile.am
@@ -59,8 +59,8 @@ test -d ./etc || mkdir ./etc
 test -d ./etc/$SUBNAME || mkdir ./etc/$SUBNAME
 
 cat << __EOF__ > etc/Makefile.am
-#dist_sysconf_DATA = $SUBNAME.conf # to omit subdir
-nobase_dist_sysconf_DATA = $SUBNAME.conf
+#dist_sysconf_DATA = $SUBNAME/$SUBNAME.conf # to omit subdir
+nobase_dist_sysconf_DATA = $SUBNAME/$SUBNAME.conf
 __EOF__
 
 test -f  etc/$SUBNAME/$SUBNAME.conf || cat << __EOF__ > etc/$SUBNAME/$SUBNAME.conf

--- a/prepare.sh
+++ b/prepare.sh
@@ -30,7 +30,7 @@ fi
 
 cat << __EOF__ > configure.ac
 AC_INIT([$SUBNAME], [0.1], [paolo@lulli.net], [$SUBNAME])
-AC_CONFIG_FILES([Makefile bin/Makefile libexec/Makefile bin/$SUBNAME])
+AC_CONFIG_FILES([Makefile bin/Makefile etc/Makefile libexec/Makefile bin/$SUBNAME ])
 AM_INIT_AUTOMAKE(foreign)
 #AC_PROG_CC
 AC_PROG_INSTALL
@@ -38,20 +38,30 @@ AC_OUTPUT
 __EOF__
 
 cat << __EOF__ > Makefile.am
-SUBDIRS = bin libexec
+SUBDIRS = bin libexec etc
 __EOF__
 
 cat << __EOF__ > libexec/Makefile.am
-dist_libexec_SCRIPTS = $SUBNAME\
-	$SUBNAME-commands\
-	$SUBNAME-completions\
-	$SUBNAME-help\
-	$SUBNAME-init\
+dist_libexec_SCRIPTS = $SUBNAME\\
+	$SUBNAME-commands\\
+	$SUBNAME-completions\\
+	$SUBNAME-help\\
+	$SUBNAME-init\\
 	$SUBNAME-sh-shell
 __EOF__
 
 cat << __EOF__ > bin/Makefile.am
 dist_bin_SCRIPTS = $SUBNAME
+__EOF__
+
+test -d ./etc || mkdir ./etc
+
+cat << __EOF__ > etc/Makefile.am
+dist_sysconf_DATA = $SUBNAME.conf
+__EOF__
+
+test -f  etc/$SUBNAME.conf || cat << __EOF__ > etc/$SUBNAME.conf
+#Here your configuration
 __EOF__
 
 rm README.md
@@ -75,6 +85,7 @@ mkdir -p \${workdir}/DEBIAN
 cp -r ./debian/* \${workdir}/DEBIAN
 ./configure "\$@"
 make install DESTDIR=\${workdir}
+test -d \$TARGET_DIR || mkdir -p \$TARGET_DIR
 dpkg-deb --build \${workdir} \$TARGET_DIR/$SUBNAME-\$VERS.deb
 
 EOF

--- a/prepare.sh
+++ b/prepare.sh
@@ -86,7 +86,8 @@ CURRDIR=\$(pwd)
 workdir=\$(mktemp -d /tmp/mkdebian_XXXXXXXX)
 mkdir -p \${workdir}/DEBIAN
 cp -r ./debian/* \${workdir}/DEBIAN
-./configure "\$@"
+#./configure "\$@"
+./configure --prefix=/
 make install DESTDIR=\${workdir}
 test -d \$TARGET_DIR || mkdir -p \$TARGET_DIR
 dpkg-deb --build \${workdir} \$TARGET_DIR/$SUBNAME-\$VERS.deb


### PR DESCRIPTION
Hi,
for my purposes I find useful having a standard way to package and install subs.
With the change in the pull request, after issuing the command:

prepare.sh xyz

you would have available the autoconf options; i.e.:

./configure --prefix=/opt/whatever

and you will be able to  install the subs by simply issuing the command:

make install

A further step could be to add *.deb, *.rpm creation on top of the standard autoconf tooling

 