### PR TITLE
BugFix for case when subcommand contains command name

### DIFF
--- a/libexec/sub-commands
+++ b/libexec/sub-commands
@@ -25,7 +25,7 @@ shopt -s nullglob
 
 { for path in ${PATH//:/$'\n'}; do
     for command in "${path}/sub-"*; do
-      command="${command##*sub-}"
+      command="${command##${path}/sub-}"
       if [ -n "$sh" ]; then
         if [ ${command:0:3} = "sh-" ]; then
           echo ${command##sh-}


### PR DESCRIPTION
Before, this would fail to list commands which contain "sub-", like `sub-sub-deploy`.

The commands always include ${path} as evidenced by the line above, so including ${path} in the regex here is more precise.