### PR TITLE
Include summary in help output for individual commands if we have it

### DIFF
--- a/libexec/sub-help
+++ b/libexec/sub-help
@@ -38,6 +38,9 @@ print_help() {
 
   if [ -n "$usage" ]; then
     echo "$usage"
+    
+    local summary="$(summary "$file")"
+    [ -n "$summary" ] && echo "Summary: $summary"
 
     local help="$(help "$file")"
     [ -n "$help" ] && echo && echo "$help"


### PR DESCRIPTION
Sometimes the "summary" is all the help that is required for a command and adding more in "Help" would redundant.
Also, sometimes "summary" serves as a useful introduction to a longer  "Help" document. 

So when people ask for the detailed "help" for a command, include the "Summary" as well as the full help.  

It's the same value as including a title when someone asks for a document.